### PR TITLE
types def weren't installed, fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "ava"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "@types/*"
   ],
   "ava": {
     "require": [


### PR DESCRIPTION
follow up to #25, due to `@types` folder not being included in the files array in package.json, the types definitions weren't retrieved on package install.