### PR TITLE
fix #27 + other bugs found in the process

### DIFF
--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -223,6 +223,574 @@ test('3 global rules equals array of lenth 3', t => {
   t.is(result.length, expectedLength);
 });
 
+test('global rules works for everything', t => {
+  const globalcss = `
+    /* Box sizing rules */
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+
+    /* Remove default padding */
+    ul[class],
+    ol[class] {
+      padding: 0;
+    }
+
+    /* Remove default margin */
+    body,
+    h1,
+    h2,
+    h3,
+    h4,
+    p,
+    ul[class],
+    ol[class],
+    li,
+    figure,
+    figcaption,
+    blockquote,
+    dl,
+    dd {
+      margin: 0;
+    }
+
+    /* Set core body defaults */
+    body {
+      min-height: 100vh;
+      scroll-behavior: smooth;
+      text-rendering: optimizeSpeed;
+      line-height: 1.5;
+    }
+
+    /* Remove list styles on ul, ol elements with a class attribute */
+    ul[class],
+    ol[class] {
+      list-style: none;
+    }
+
+    /* A elements that don't have a class get default styles */
+    a:not([class]) {
+      text-decoration-skip-ink: auto;
+    }
+
+    /* Make images easier to work with */
+    img {
+      max-width: 100%;
+      display: block;
+    }
+
+    /* Natural flow and rhythm in articles by default */
+    article > * + * {
+      margin-top: 1em;
+    }
+
+    /* Inherit fonts for inputs and buttons */
+    input,
+    button,
+    textarea,
+    select {
+      font: inherit;
+    }
+
+    /* Remove all animations and transitions for people that prefer not to see them */
+    @media (prefers-reduced-motion: reduce) {
+      * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    .content {
+      color: lime;
+    }
+
+    #main-button_accent {
+      color: lime;
+    }
+
+    * {
+      color: lime;
+    }
+
+    a[title] {
+      color: purple;
+    }
+
+    a[href="https://example.org"] {
+      color: green;
+    }
+
+    a[class~="logo"] {
+      padding: 2px;
+    }
+
+    a[href*="example"] {
+      font-size: 2em;
+    }
+
+    a[href$=".org"] {
+      font-style: italic;
+    }
+
+    .i1::-webkit-slider-thumb {
+      color: blue;
+    }
+
+    .i1:nth-child(4n) {
+      color: lime;
+    }
+
+    .i1 > div {
+      color: lime;
+    }
+
+    .i1 > .content {
+      color: lime;
+    }
+
+    .i1 + div {
+      color: lime;
+    }
+
+    .i1 ~ div {
+      color: lime;
+    }
+
+    .i1 {
+      width: inherit;
+    }
+
+    .i1 {
+      transition-timing-function: ease-in;
+    }
+
+    .i1 {
+      font: 12px/18px;
+    }
+
+    .i1 {
+      color: rgb(20, 20, 20);
+    }
+
+    .i1 {
+      font-size: 1.2rem;
+    }
+
+    .i1 {
+      top: -12px;
+    }
+
+    .i1 {
+      top: +12px;
+    }
+
+    .i1::before {
+      content: "\\25C0";
+    }
+
+    .i1 {
+      top: -12px !important;
+    }
+
+    @media screen and (max-width: 992px) {
+      .content {
+        color: lime;
+      }
+
+      #main-button_accent {
+        color: lime;
+      }
+
+      * {
+        color: lime;
+      }
+
+      a[title] {
+        color: purple;
+      }
+
+      a[href="https://example.org"] {
+        color: green;
+      }
+
+      a[class~="logo"] {
+        padding: 2px;
+      }
+
+      a[href*="example"] {
+        font-size: 2em;
+      }
+
+      a[href$=".org"] {
+        font-style: italic;
+      }
+
+      .i1::-webkit-slider-thumb {
+        color: blue;
+      }
+
+      .i1:nth-child(4n) {
+        color: lime;
+      }
+
+      .i1 > div {
+        color: lime;
+      }
+
+      .i1 > .content {
+        color: lime;
+      }
+
+      .i1 + div {
+        color: lime;
+      }
+
+      .i1 ~ div {
+        color: lime;
+      }
+
+      .i1 {
+        width: inherit;
+      }
+
+      .i1 {
+        transition-timing-function: ease-in;
+      }
+
+      .i1 {
+        font: 12px/18px;
+      }
+
+      .i1 {
+        color: rgb(20, 20, 20);
+      }
+
+      .i1 {
+        font-size: 1.2rem;
+      }
+
+      .i1 {
+        top: -12px;
+      }
+
+      .i1 {
+        top: +12px;
+      }
+
+      .i1::before {
+        content: "\\25C0";
+      }
+
+      .i1 {
+        top: -12px !important;
+      }
+
+    }
+  `;
+  const result = globalRules(globalcss);
+  function assertglobalStyle(expected) {
+    t.true(
+      !!result.find(el => el.replace(/[\r\n\s]/gm, '') === expected.replace(/[\r\n\s]/gm, ''))
+    );
+  }
+  t.plan(result.length);
+  assertglobalStyle(`
+    *,
+    *::before,
+    *::after {
+      box-sizing: border-box;
+    }
+  `);
+  assertglobalStyle(`
+    ul[class],
+    ol[class] {
+      padding: 0;
+    }
+  `);
+  assertglobalStyle(`
+    body,
+    h1,
+    h2,
+    h3,
+    h4,
+    p,
+    ul[class],
+    ol[class],
+    li,
+    figure,
+    figcaption,
+    blockquote,
+    dl,
+    dd {
+      margin: 0;
+    }
+  `);
+  assertglobalStyle(`
+    body {
+      min-height: 100vh;
+      scroll-behavior: smooth;
+      text-rendering: optimizeSpeed;
+      line-height: 1.5;
+    }
+  `);
+  assertglobalStyle(`
+    ul[class],
+    ol[class] {
+      list-style: none;
+    }
+  `);
+  assertglobalStyle(`
+    a:not([class]) {
+      text-decoration-skip-ink: auto;
+    }
+  `);
+  assertglobalStyle(`
+    img {
+      max-width: 100%;
+      display: block;
+    }
+  `);
+  assertglobalStyle(`
+    article > * + * {
+      margin-top: 1em;
+    }
+  `);
+  assertglobalStyle(`
+    input,
+    button,
+    textarea,
+    select {
+      font: inherit;
+    }
+  `);
+  assertglobalStyle(`
+    @media (prefers-reduced-motion: reduce) {
+      * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+  `);
+  assertglobalStyle(`
+    .content {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    #main-button_accent {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    * {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    a[title] {
+      color: purple;
+    }
+  `);
+  assertglobalStyle(`
+    a[href="https://example.org"] {
+      color: green;
+    }
+  `);
+
+  assertglobalStyle(`
+    a[class~="logo"] {
+      padding: 2px;
+    }
+  `);
+  assertglobalStyle(`
+    a[href*="example"] {
+      font-size: 2em;
+    }
+  `);
+  assertglobalStyle(`
+    a[href$=".org"] {
+      font-style: italic;
+    }
+  `);
+  assertglobalStyle(`
+    .i1::-webkit-slider-thumb {
+      color: blue;
+    }
+  `);
+  assertglobalStyle(`
+    .i1:nth-child(4n) {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 > div {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 > .content {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 + div {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 ~ div {
+      color: lime;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      width: inherit;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      transition-timing-function: ease-in;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      font: 12px/18px;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      color: rgb(20, 20, 20);
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      font-size: 1.2rem;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      top: -12px;
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      top: +12px;
+    }
+  `);
+  assertglobalStyle(`
+    .i1::before {
+      content: "\\25C0";
+    }
+  `);
+  assertglobalStyle(`
+    .i1 {
+      top: -12px !important;
+    }
+  `);
+  assertglobalStyle(`
+    @media screen and (max-width: 992px) {
+      .content {
+        color: lime;
+      }
+
+      #main-button_accent {
+        color: lime;
+      }
+
+      * {
+        color: lime;
+      }
+
+      a[title] {
+        color: purple;
+      }
+
+      a[href="https://example.org"] {
+        color: green;
+      }
+
+      a[class~="logo"] {
+        padding: 2px;
+      }
+
+      a[href*="example"] {
+        font-size: 2em;
+      }
+
+      a[href$=".org"] {
+        font-style: italic;
+      }
+
+      .i1::-webkit-slider-thumb {
+        color: blue;
+      }
+
+      .i1:nth-child(4n) {
+        color: lime;
+      }
+
+      .i1 > div {
+        color: lime;
+      }
+
+      .i1 > .content {
+        color: lime;
+      }
+
+      .i1 + div {
+        color: lime;
+      }
+
+      .i1 ~ div {
+        color: lime;
+      }
+
+      .i1 {
+        width: inherit;
+      }
+
+      .i1 {
+        transition-timing-function: ease-in;
+      }
+
+      .i1 {
+        font: 12px/18px;
+      }
+
+      .i1 {
+        color: rgb(20, 20, 20);
+      }
+
+      .i1 {
+        font-size: 1.2rem;
+      }
+
+      .i1 {
+        top: -12px;
+      }
+
+      .i1 {
+        top: +12px;
+      }
+
+      .i1::before {
+        content: "\\25C0";
+      }
+
+      .i1 {
+        top: -12px !important;
+      }
+
+    }
+  `);
+});
+
 test('extract pseudo selector rules where pseudo selector has dash (-webkit-slider-thumb for example)', t => {
   const scopedcss = `
     ::-webkit-slider-thumb {
@@ -261,6 +829,13 @@ test('multiple comma separated values and whitespace for selector', t => {
     :active {
       color: red;
     }
+
+    @media screen and (max-width: 992px) {
+      :hover,:focus,
+      :active {
+        color: red;
+      }
+    }
   `;
   const className = 'i1';
   const result = pseudoSelectorRules(scopedcss, className);
@@ -276,6 +851,21 @@ test('multiple comma separated values and whitespace for selector', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1:hover {
+        color: red;
+      }
+      .i1:focus {
+        color: red;
+      }
+      .i1:active {
+        color: red;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Type_selectors
@@ -300,9 +890,15 @@ test('Type selectors in combinator', t => {
  */
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors
 test('Class selectors in combinator', t => {
+  t.plan(2);
   const scopedcss = `
     > .content {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      > .content {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
@@ -313,30 +909,60 @@ test('Class selectors in combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 > .content {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors
 test('ID selectors in combinator', t => {
+  t.plan(2);
   const scopedcss = `
-    > #main-button {
+    > #main-button_accent {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      > #main-button_accent {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
   const result = pseudoSelectorRules(scopedcss, className);
   const expected = `
-    .i1 > #main-button {
+    .i1 > #main-button_accent {
       color: lime;
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 > #main-button_accent {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors
 test('Universal selectors in combinator', t => {
+  t.plan(2);
   const scopedcss = `
     > * {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      > * {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
@@ -347,10 +973,20 @@ test('Universal selectors in combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 > * {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
 test('Attribute selectors in combinator', t => {
+  t.plan(2);
   const scopedcss = `
     /* <a> elements with a title attribute */
     > a[title] {
@@ -375,6 +1011,33 @@ test('Attribute selectors in combinator', t => {
     /* <a> elements whose class attribute contains the word "logo", same as a.logo */
     > a[class~="logo"] {
       padding: 2px;
+    }
+
+    @media screen and (max-width: 992px) {
+      /* <a> elements with a title attribute */
+      > a[title] {
+        color: purple;
+      }
+
+      /* <a> elements with an href matching "https://example.org" */
+      > a[href="https://example.org"] {
+        color: green;
+      }
+
+      /* <a> elements with an href containing "example" */
+      > a[href*="example"] {
+        font-size: 2em;
+      }
+
+      /* <a> elements with an href ending ".org" */
+      > a[href$=".org"] {
+        font-style: italic;
+      }
+
+      /* <a> elements whose class attribute contains the word "logo", same as a.logo */
+      > a[class~="logo"] {
+        padding: 2px;
+      }
     }
   `;
   const className = 'i1';
@@ -401,6 +1064,31 @@ test('Attribute selectors in combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 > a[title] {
+        color: purple;
+      }
+
+      .i1 > a[href="https://example.org"] {
+        color: green;
+      }
+
+      .i1 > a[href*="example"] {
+        font-size: 2em;
+      }
+
+      .i1 > a[href$=".org"] {
+        font-style: italic;
+      }
+
+      .i1 > a[class~="logo"] {
+        padding: 2px;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 /**
@@ -408,9 +1096,15 @@ test('Attribute selectors in combinator', t => {
  */
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_combinator
 test('Adjacent sibling combinator', t => {
+  t.plan(2);
   const scopedcss = `
     + div {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      + div {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
@@ -421,13 +1115,28 @@ test('Adjacent sibling combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 + div {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator
 test('General sibling combinator', t => {
+  t.plan(2);
   const scopedcss = `
     ~ div {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      ~ div {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
@@ -438,13 +1147,28 @@ test('General sibling combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 ~ div {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/Child_combinator
 test('Child combinator', t => {
+  t.plan(2);
   const scopedcss = `
     > div {
       color: lime;
+    }
+    @media screen and (max-width: 992px) {
+      > div {
+        color: lime;
+      }
     }
   `;
   const className = 'i1';
@@ -455,6 +1179,15 @@ test('Child combinator', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+  const result2 = atRules(scopedcss, className);
+  const expected2 = `
+    @media screen and (max-width: 992px) {
+      .i1 > div {
+        color: lime;
+      }
+    }
+  `;
+  assertStyle(t, expected2, result2.join(''));
 });
 
 test('checkbox or radio button', t => {
@@ -987,4 +1720,47 @@ test('css property value : special characters in content property', t => {
     }
   `;
   assertStyle(t, expected, result.join(''));
+});
+
+test('css property value : "!important"', t => {
+  t.plan(3);
+  const scopedcss = `
+    top: -12px !important;
+    :hover {
+      top: -12px !important;
+    }
+    @media screen and (max-width: 992px) {
+      top: -12px !important;
+      :hover {
+        top: -12px !important;
+      }
+    }
+  `;
+  const className = 'i1';
+  const result = mainRule(scopedcss, className);
+  const expected = `
+    .i1 {
+      top: -12px !important;
+    }
+  `;
+  assertStyle(t, expected, result);
+  const pseudoSelectorRulesResult = pseudoSelectorRules(scopedcss, className);
+  const pseudoSelectorRulesExpected = `
+    .i1:hover {
+      top: -12px !important;
+    }
+  `;
+  assertStyle(t, pseudoSelectorRulesExpected, pseudoSelectorRulesResult.join(''));
+  const atRulesResult = atRules(scopedcss, className);
+  const atRulesExpected = `
+    @media screen and (max-width: 992px) {
+      .i1 {
+        top: -12px !important;
+      }
+      .i1:hover {
+        top: -12px !important;
+      }
+    }
+  `;
+  assertStyle(t, atRulesExpected, atRulesResult.join(''));
 });


### PR DESCRIPTION
This is a fix for #27, the global style regex wasn't supporting many things: class selectors, id selectors, universal selectors, attribute selectors, adjacent sibling combinator, general sibling combinator, child combinator, media queries.
This also adds supports for `!important`, underscores in classnames and ids for global and scoped rules.
Better css comment support (before comments could only be placed at the root of the rules).
And fixes `pseudoSelector` computation inside `atRule`.
